### PR TITLE
SC-12009 fix(classes/Connector.php): prevent customer groups to be reset.

### DIFF
--- a/sendcloud/sendcloud.php
+++ b/sendcloud/sendcloud.php
@@ -56,7 +56,7 @@ class Sendcloud extends CarrierModule
         $this->boostrap = true;
         $this->name = 'sendcloud';
         $this->tab = 'shipping_logistics';
-        $this->version = '1.1.3';
+        $this->version = '1.1.4';
         $this->author = 'SendCloud Global B.V.';
         $this->author_uri = 'https://sendcloud.eu';
         $this->need_instance = false;
@@ -387,8 +387,7 @@ class Sendcloud extends CarrierModule
         $carrier = $this->connector->getOrSynchroniseCarrier();
 
         if ($cart->id_carrier != $carrier->id) {
-            // A user may not enable service points at all may
-            // selected another carrier.
+            // A user may not enable service points at all and have selected another carrier.
             return true;
         }
 


### PR DESCRIPTION
**The problem:** everytime a synchronization of the carrier was necessary the assignment of customer groups were taking _all_ available groups instead of the same groups used by the previous version of the same carrier.

We now try to get previously assigned groups whenever a synchronization is necessary.