### PR TITLE
fix(classes/Connector.php): Do not override carrier groups.

### DIFF
--- a/sendcloud/sendcloud.php
+++ b/sendcloud/sendcloud.php
@@ -56,7 +56,7 @@ class Sendcloud extends CarrierModule
         $this->boostrap = true;
         $this->name = 'sendcloud';
         $this->tab = 'shipping_logistics';
-        $this->version = '1.1.4';
+        $this->version = '1.1.5';
         $this->author = 'SendCloud Global B.V.';
         $this->author_uri = 'https://sendcloud.eu';
         $this->need_instance = false;


### PR DESCRIPTION
Fallback to all available carrier groups only when there is no group assigned to the current carrier.

The previous implementation was incompatible with PrestaShop 1.7 as it doesn't really require much work related to carrier groups. PrestaShop 1.6 also does provide the correct groups and we now use all active customer groups only as a fallback.