### PR TITLE
fix(AdminSendcloudController.php): enable secure mode to support https

### DIFF
--- a/sendcloud/controllers/admin/AdminSendcloudController.php
+++ b/sendcloud/controllers/admin/AdminSendcloudController.php
@@ -283,7 +283,7 @@ class AdminSendcloudController extends ModuleAdminController
         $shop = $this->context->shop;
 
         $query_params = array(
-            'url_webshop' => $shop->getBaseURL(),
+            'url_webshop' => $shop->getBaseURL(true),
             'api_key' => $data['key'],
             'shop_name' => $shop->name,
             'shop_id' => $shop->id,

--- a/sendcloud/sendcloud.php
+++ b/sendcloud/sendcloud.php
@@ -58,7 +58,7 @@ class Sendcloud extends CarrierModule
         $this->tab = 'shipping_logistics';
         $this->version = '1.4.2';
         $this->author = 'Sendcloud';
-        $this->author_uri = 'https://sendcloud.eu';
+        $this->author_uri = 'https://sendcloud.com';
         $this->need_instance = false;
         $this->ps_versions_compliancy = array('min' => '1.5','max'=> '1.7');
         $this->module_key = 'ee5ffe2f68aefd272e994aa5a26e6224';

--- a/sendcloud/sendcloud.php
+++ b/sendcloud/sendcloud.php
@@ -56,7 +56,7 @@ class Sendcloud extends CarrierModule
         $this->boostrap = true;
         $this->name = 'sendcloud';
         $this->tab = 'shipping_logistics';
-        $this->version = '1.4.1';
+        $this->version = '1.4.2';
         $this->author = 'Sendcloud';
         $this->author_uri = 'https://sendcloud.eu';
         $this->need_instance = false;


### PR DESCRIPTION
**Problem**
Our plugin always sends us a shop URL that starts from `http:\\`, even if the shop is running under HTTPS. According to the Prestashop Github [source code](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/shop/Shop.php#L528) we have to pass the `true` flag to the `getBaseURL` to support HTTPS URLs.  Also, I found an [example](https://stackoverflow.com/a/45648506) of using this function on StackOverflow with the `true` flag or the [example](https://www.prestashop.com/forums/topic/263420-solved-how-to-get-site-baseurl/?do=findComment&comment=2595795) on the Prestashop forum. As the result, we have all our calls to the shops over HTTP which leads to some unexpected bugs when redirect from HTTP to HTTPS is enabled on the client's side. 

**Examples and Proofs**
As an example, you can check this [user](https://panel.sendcloud.sc/admin-ng/shops/prestashopintegration/105386/change/). The `url_webshop` is set to `http` in the settings, but if you try to open the URL in the browser, you will see that you were redirected to the HTTPS. Also, you can see 500 errors like[ this one ](https://panel.sendcloud.sc/admin-ng/shops/integrationlog/45114932/change/). The request params are looks like it's a POST request, but the payload is missing, the request method changed to GET and URL is changed from HTTP to HTTPS. Sometimes it can happen when we deal with redirects. Here is an article about it https://rtfm.co.ua/en/http-redirects-post-and-get-requests-and-lost-data/
I was able to test the updated plugin version with our test shop and I can confirm that previously we had HTTP and now we have HTTPS where needed